### PR TITLE
Adjust motor driver response validation

### DIFF
--- a/arctos/motor_driver.py
+++ b/arctos/motor_driver.py
@@ -158,8 +158,7 @@ class MotorDriver:
         resp = self._send_and_receive(bytes([0xF3, val]))
         if resp is None or len(resp) < 2:
             return False
-        expected_status = 1 if enabled else 0
-        return resp[1] == expected_status
+        return resp[1] == 1
 
     def move_to_axis(self, position: int, speed: int, acc: int) -> bool:
         """Absolute axis move (command 0xF5). Returns True if accepted."""
@@ -172,7 +171,7 @@ class MotorDriver:
         resp = self._send_and_receive(data)
         if resp is None or len(resp) < 2:
             return False
-        return resp[1] == 2
+        return resp[1] in (1, 2)
 
     def set_speed(self, direction: int, speed: int, acc: int) -> bool:
         """Speed mode (command 0xF6). Returns True if accepted."""
@@ -181,7 +180,7 @@ class MotorDriver:
         resp = self._send_and_receive(data)
         if resp is None or len(resp) < 2:
             return False
-        return resp[1] == 2
+        return resp[1] in (1, 2)
 
     def stop(self, acc: int = 0) -> bool:
         """Stop motor via speed mode with speed=0 (command 0xF6).
@@ -192,7 +191,7 @@ class MotorDriver:
         resp = self._send_and_receive(data)
         if resp is None or len(resp) < 2:
             return False
-        return resp[1] == 2
+        return resp[1] in (1, 2)
 
     def emergency_stop(self) -> bool:
         """Emergency stop (command 0xF7). Returns True if confirmed."""

--- a/scripts/test_all_commands.py
+++ b/scripts/test_all_commands.py
@@ -82,9 +82,14 @@ def test_read(
 def test_enable(driver: MotorDriver, enable: bool) -> TestResult:
     """Send enable/disable and verify response."""
     label = "Enable motor (0xF3)" if enable else "Disable motor (0xF3)"
-    ok = driver.enable(enable)
-    if not ok:
+    val = 0x01 if enable else 0x00
+    resp = driver.raw_command(bytes([0xF3, val]))
+    if resp is None:
         return TestResult(label, False, "No response")
+    if resp[0] != 0xF3 or len(resp) < 2:
+        return TestResult(label, False, f"Unexpected: {resp.hex()}")
+    if resp[1] != 1:
+        return TestResult(label, False, f"Status: {resp[1]}")
     return TestResult(label, True, "Enabled" if enable else "Disabled")
 
 
@@ -201,11 +206,11 @@ def test_emergency_stop(driver: MotorDriver) -> TestResult:
 
 
 def test_read_speed_zero(driver: MotorDriver) -> TestResult:
-    """Read speed (0x32) and verify it's 0."""
+    """Read speed (0x32) and verify it's near 0."""
     speed = driver.read_speed()
     if speed is None:
         return TestResult("Verify speed=0 (0x32)", False, "No response")
-    ok = speed == 0
+    ok = abs(speed) <= 20
     return TestResult("Verify speed=0 (0x32)", ok, f"{speed} RPM")
 
 

--- a/tests/test_motor_driver.py
+++ b/tests/test_motor_driver.py
@@ -202,7 +202,7 @@ def test_enable_on(can_pair, motor):
 def test_enable_off(can_pair, motor):
     _, motor_can = can_pair
     result = _run_with_simulated_response(
-        motor_can, bytes([0xF3, 0x00]), lambda: motor.enable(False)
+        motor_can, bytes([0xF3, 0x01]), lambda: motor.enable(False)
     )
     assert result is True
 


### PR DESCRIPTION
Normalize and relax response checks from the motor driver: enable() now treats a status byte of 0x01 as successful regardless of requested state, and move_to_axis, set_speed and stop accept either 0x01 or 0x02 as valid accept/ack statuses. Update test script test_all_commands.py to inspect raw 0xF3 responses directly and treat small nonzero speeds (±20 RPM) as acceptable in the read_speed check. Update unit test to simulate the updated disable acknowledgement (0x01). These changes make the code resilient to different valid status codes from the device and align tests with observed device behavior.